### PR TITLE
Add fixed SeqFilter commit & shrink final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL maintainer="frank.foerster@ime.fraunhofer.de" \
 
 WORKDIR /opt
 
-RUN apt update && apt install --yes git make && git clone https://github.com/BioInf-Wuerzburg/SeqFilter.git && cd SeqFilter && git checkout d92ff27b810be76e4f9394c4f9e98648ebfbc915 && make
+RUN apt update && apt install --yes git make && git clone https://github.com/BioInf-Wuerzburg/SeqFilter.git && cd SeqFilter && git checkout d92ff27b810be76e4f9394c4f9e98648ebfbc915 && make && rm -rf .git && apt remove --yes git make
 
 ENV PATH "$PATH:/opt/SeqFilter/bin/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL maintainer="frank.foerster@ime.fraunhofer.de" \
 
 WORKDIR /opt
 
-RUN apt update && apt install --yes git make && git clone https://github.com/BioInf-Wuerzburg/SeqFilter.git && cd SeqFilter && make
+RUN apt update && apt install --yes git make && git clone https://github.com/BioInf-Wuerzburg/SeqFilter.git && cd SeqFilter && git checkout d92ff27b810be76e4f9394c4f9e98648ebfbc915 && make
 
 ENV PATH "$PATH:/opt/SeqFilter/bin/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,20 @@ LABEL maintainer="frank.foerster@ime.fraunhofer.de" \
 
 WORKDIR /opt
 
-RUN apt update && apt install --yes git make && git clone https://github.com/BioInf-Wuerzburg/SeqFilter.git && cd SeqFilter && git checkout d92ff27b810be76e4f9394c4f9e98648ebfbc915 && make && rm -rf .git && apt remove --yes git make
+RUN apt update && \
+    apt install --yes \
+	git \
+	make && \
+    git clone https://github.com/BioInf-Wuerzburg/SeqFilter.git && \
+    cd SeqFilter && \
+    git checkout d92ff27b810be76e4f9394c4f9e98648ebfbc915 && \
+    make && \
+    rm -rf .git && \
+    apt remove --yes \
+	git \
+	make && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV PATH "$PATH:/opt/SeqFilter/bin/"
 


### PR DESCRIPTION
The SeqFilter is now fixed to the commit https://github.com/BioInf-Wuerzburg/SeqFilter/commit/d92ff27b810be76e4f9394c4f9e98648ebfbc915 and the final docker image was shrinken by removing git/make and unused repository content.